### PR TITLE
chore: publish to jsr

### DIFF
--- a/.github/workflows/release-to-jsr.yml
+++ b/.github/workflows/release-to-jsr.yml
@@ -1,4 +1,5 @@
 name: Release to JSR
+
 on:
   push:
     branches:

--- a/.github/workflows/release-to-jsr.yml
+++ b/.github/workflows/release-to-jsr.yml
@@ -1,0 +1,19 @@
+name: Release to JSR
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish package
+        run: npx jsr publish

--- a/jsr.json
+++ b/jsr.json
@@ -1,0 +1,6 @@
+{
+  "name": "@eggjs/read-env-value",
+  "version": "1.0.0",
+  "license": "MIT",
+  "exports": "./src/index.ts"
+}


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Adds JSR (JavaScript Registry) configuration to publish the read-env-value package under the @eggjs namespace.

- Created `jsr.json` configuration file to enable publishing to JSR registry with the package name "@eggjs/read-env-value".
- Set up the package exports to point to the TypeScript source file directly, allowing TypeScript consumers to import types.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a package configuration file specifying package details, version, license, and entry point.
  - Introduced a new automated workflow to streamline package publishing on code updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->