### PR TITLE
fix: Fixed 0 or false misjudgments

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -89,6 +89,21 @@ test('should work with boolean value', () => {
 
   mock(process.env, 'TEST_ENV_BOOLEAN', '0');
   assert.equal(env('TEST_ENV_BOOLEAN', 'boolean', true), false);
+
+  mock(process.env, 'TEST_ENV_BOOLEAN', 'yes');
+  assert.equal(env('TEST_ENV_BOOLEAN', 'boolean', true), true);
+
+  mock(process.env, 'TEST_ENV_BOOLEAN', 'no');
+  assert.equal(env('TEST_ENV_BOOLEAN', 'boolean', false), false);
+
+  mock(process.env, 'TEST_ENV_BOOLEAN', false);
+  assert.equal(env('TEST_ENV_BOOLEAN', 'boolean', false), false);
+
+  mock(process.env, 'TEST_ENV_BOOLEAN', 0);
+  assert.equal(env('TEST_ENV_BOOLEAN', 'boolean', false), false);
+
+  mock(process.env, 'TEST_ENV_BOOLEAN', 0);
+  assert.equal(env('TEST_ENV_BOOLEAN', 'boolean', false), false);
 });
 
 test('should work with number value', () => {


### PR DESCRIPTION
<!--- SUMMARY_MARKER --->
## Sweep Summary <sub><a href="https://app.sweep.dev"><img src="https://raw.githubusercontent.com/sweepai/sweep/main/.assets/sweep-square.png" width="25" alt="Sweep"></a></sub>

Fixed a bug where falsy environment values (0 or false) were incorrectly treated as missing values, causing default values to be used instead.

- Changed the condition in `src/index.ts` from `if (!value)` to `if (undefined === value || value === '')` to properly handle falsy values like 0 and false.
- Added support for 'yes' and 'no' as valid boolean values in addition to 'true'/'false' and '1'/'0'.
- Implemented a custom `EnvError` class with specific error codes for better error handling.
- Added test cases in `test/index.test.ts` to verify correct handling of falsy values and new boolean formats.

---
[Ask Sweep AI questions about this PR](https://app.sweep.dev)
<!--- SUMMARY_MARKER --->

在`process.env.TEST_ENV_BOOLEAN = 0`的情况下，会被错误的赋予默认值。

修复前
`
if (!value) {
    return defaultValue as EnvReturn<V, D>;
}
`

修复后
`
 if (undefined === value || value === '') {
    return defaultValue as EnvReturn<V, D>;
  }
`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced boolean environment variable parsing to support "yes" and "no" (case-insensitive) as valid values.
- **Bug Fixes**
  - Improved handling of empty environment variable values for more accurate detection.
- **Tests**
  - Added tests to verify correct parsing of "yes", "no", false, and 0 as boolean environment variable values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->